### PR TITLE
Feature : floating/autohide color picker 

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ const App = () => {
 | `stopRemovalDrop` | `Number` | `50` | No | Sets the Y stop drop removal offset, If the user will drag the color stop further than specified, Color will be removed
 | `maxStops` | `Number` | `5` | No | The max gradient picker palette length can have
 | `minStops` | `Number` | `2` | No | The min gradient picker palette length can have
+| `floatingPicker` | `Boolean` | `false` | No | The color picker is now positioned in absolute and auto hide when user click outside
 
 PaletteColor = shape({
 	color: string.isRequired,

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ const App = () => {
 | `maxStops` | `Number` | `5` | No | The max gradient picker palette length can have
 | `minStops` | `Number` | `2` | No | The min gradient picker palette length can have
 | `floatingPicker` | `Boolean` | `false` | No | The color picker is now positioned in absolute and auto hide when user click outside
+| `angle` | `Number` | `90` | No | Define the angle to use for the gradient picker
 
 PaletteColor = shape({
 	color: string.isRequired,
@@ -88,3 +89,4 @@ const App = () => {
 | `onChange` | `Function` | `undefined` | Yes | The on change to be trigger after an angle was changes.
 | `size` | `Number` | `48` | No | Determines the size of the angle picker
 | `snap` | `Number` | `5` | No | Determines the angle change snapping, Can be removed with setting as 0
+| `showValue` | `boolean` | `false` | No | Determines if the angle should be displayed inside the picker

--- a/src/components/AnglePicker/index.css
+++ b/src/components/AnglePicker/index.css
@@ -32,3 +32,13 @@
     margin: auto;
     cursor: pointer;
 }
+
+.ap .apl {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 12px;
+    font-weight: bold;
+}

--- a/src/components/AnglePicker/index.js
+++ b/src/components/AnglePicker/index.js
@@ -9,7 +9,7 @@ import {
 } from '../../lib';
 import './index.css';
 
-const AnglePicker = ({ angle, onChange, size = 48, snap = 5 }) => {
+const AnglePicker = ({ angle, onChange, size = 48, snap = 5, showValue = false }) => {
 	const pickerRef = useRef();
 	const sizeStyle = { height: size, width: size };
 
@@ -40,6 +40,7 @@ const AnglePicker = ({ angle, onChange, size = 48, snap = 5 }) => {
 			<span className="apc" style={{ transform: `rotate(${angle}deg)`, height: size }}>
 				<i className="aph"/>
 			</span>
+			{showValue && <span className="apl">{angle}°</span>}
 		</div>
 	);
 };

--- a/src/components/GradientPicker/constants.js
+++ b/src/components/GradientPicker/constants.js
@@ -13,3 +13,5 @@ export const DEFAULT_MAX_STOPS = 5;
 export const DEFAULT_MIN_STOPS = 2;
 
 export const DEFAULT_FLOATING_PICKER = false;
+
+export const DEFAULT_ANGLE = 90;

--- a/src/components/GradientPicker/constants.js
+++ b/src/components/GradientPicker/constants.js
@@ -11,3 +11,5 @@ export const DEFAULT_HEIGHT = 32;
 export const DEFAULT_MAX_STOPS = 5;
 
 export const DEFAULT_MIN_STOPS = 2;
+
+export const DEFAULT_FLOATING_PICKER = false;

--- a/src/components/GradientPicker/index.css
+++ b/src/components/GradientPicker/index.css
@@ -1,5 +1,6 @@
 .gp {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  position: relative;
 }

--- a/src/components/GradientPicker/index.js
+++ b/src/components/GradientPicker/index.js
@@ -11,7 +11,8 @@ import {
 	DEFAULT_STOP_REMOVAL_DROP,
 	DEFAULT_MAX_STOPS,
 	DEFAULT_MIN_STOPS,
-	DEFAULT_FLOATING_PICKER
+	DEFAULT_FLOATING_PICKER,
+	DEFAULT_ANGLE
 } from './constants';
 import './index.css';
 
@@ -60,7 +61,8 @@ const GradientPicker = ({
 	maxStops = DEFAULT_MAX_STOPS,
 	children,
 	onPaletteChange,
-	floatingPicker = DEFAULT_FLOATING_PICKER
+	floatingPicker = DEFAULT_FLOATING_PICKER,
+	angle = DEFAULT_ANGLE
 }) => {
 	palette = mapIdToPalette(palette);
 
@@ -138,7 +140,6 @@ const GradientPicker = ({
 				zIndex: 3,
 				top: '100%'
 			};
-	
 			if (floatingPicker && !showPicker) {
 				style.display = 'none';
 			}
@@ -159,7 +160,7 @@ const GradientPicker = ({
 
 	return (
 		<div className="gp" ref={mainRef}>
-			<Palette width={paletteWidth} height={paletteHeight} palette={palette}/>
+			<Palette width={paletteWidth} height={paletteHeight} palette={palette} angle={angle}/>
 			<ColorStopsHolder
 				width={paletteWidth}
 				disabled={stopsHolderDisabled}

--- a/src/components/Palette/index.js
+++ b/src/components/Palette/index.js
@@ -1,26 +1,15 @@
-import React, { useMemo } from 'react';
-import { sortPalette } from '../../lib';
+import React from 'react';
+import { sortPalette, getGradientPreview } from '../../lib';
 import { PALETTE_PROP_TYPES } from '../propTypes';
 
-const generateGradientId = () => '' + Math.random().toString(36).substr(2, 9);
-
-const Palette = ({ palette, width, height }) => {
-	const sortedPalette = sortPalette(palette);
-	const gradientId = useMemo(generateGradientId, [palette.length]);
+const Palette = ({ palette, width, height, angle = 90 }) => {
+	const preview = getGradientPreview(sortPalette(palette), angle);
 
 	return (
-		<div className="palette" style={{ width, height }}>
-			<svg width="100%" height="100%">
-				<defs>
-					<linearGradient id={gradientId} x1="0" y1="0.5" x2="1" y2="0.5"> {
-						sortedPalette.map(({ id, offset, color, opacity = 1 }) =>
-							<stop key={id} offset={offset} style={{ stopColor: color, stopOpacity: opacity }}/>
-						)}
-					</linearGradient>
-				</defs>
-				<rect x="0" y="0" width="100%" height="100%" fill={`url(#${gradientId})`}/>
-			</svg>
-		</div>
+		<div
+			className="palette"
+			style={{ width, height, background: preview.background }}
+		/>
 	);
 };
 

--- a/src/components/propTypes/index.js
+++ b/src/components/propTypes/index.js
@@ -45,7 +45,8 @@ export const STOPS_HOLDER_PROP_TYPES = {
 export const PALETTE_PROP_TYPES = {
 	width: number.isRequired,
 	height: number.isRequired,
-	palette: arrayOf(PALETTE_COLOR_SHAPE).isRequired
+	palette: arrayOf(PALETTE_COLOR_SHAPE).isRequired,
+	angle: number.isRequired
 };
 
 export const GRADIENT_PICKER_PROP_TYPES = {
@@ -56,7 +57,8 @@ export const GRADIENT_PICKER_PROP_TYPES = {
 	maxStops: number,
 	minStops: number,
 	palette: arrayOf(PALETTE_COLOR_SHAPE),
-	floatingPicker: bool
+	floatingPicker: bool,
+	angle: number
 };
 
 export const ANGLE_PICKER_PROP_TYPES = {

--- a/src/components/propTypes/index.js
+++ b/src/components/propTypes/index.js
@@ -55,7 +55,8 @@ export const GRADIENT_PICKER_PROP_TYPES = {
 	stopRemovalDrop: number,
 	maxStops: number,
 	minStops: number,
-	palette: arrayOf(PALETTE_COLOR_SHAPE)
+	palette: arrayOf(PALETTE_COLOR_SHAPE),
+	floatingPicker: bool
 };
 
 export const ANGLE_PICKER_PROP_TYPES = {

--- a/stories/Story.css
+++ b/stories/Story.css
@@ -60,3 +60,7 @@ hr {
     align-items: center;
     flex-direction: column;
 }
+
+.agps .ap {
+    margin-left: 20px;
+}

--- a/stories/UseCase.js
+++ b/stories/UseCase.js
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types';
 import { getGradientPreview } from '../src/lib';
 import { GradientPicker } from '../src';
 
-const UseCase = ({ floatingPicker, palette, ColorPicker, link, title }) => {
+const UseCase = ({ floatingPicker, palette, ColorPicker, angle = 90, link, title }) => {
 	const [localPalette, setLocalPalette] = useState(palette);
 
-	const { background, angle } = getGradientPreview(localPalette);
+	const { background } = getGradientPreview(localPalette, angle);
 
 	const info = JSON.stringify(localPalette);
 
@@ -39,7 +39,9 @@ UseCase.propTypes = {
 	palette: PropTypes.array,
 	ColorPicker: PropTypes.any,
 	link: PropTypes.string,
-	title: PropTypes.string
+	title: PropTypes.string,
+	floatingPicker: PropTypes.bool,
+	angle: PropTypes.number
 };
 
 export default UseCase;

--- a/stories/UseCase.js
+++ b/stories/UseCase.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { getGradientPreview } from '../src/lib';
 import { GradientPicker } from '../src';
 
-const UseCase = ({ palette, ColorPicker, link, title }) => {
+const UseCase = ({ floatingPicker, palette, ColorPicker, link, title }) => {
 	const [localPalette, setLocalPalette] = useState(palette);
 
 	const { background, angle } = getGradientPreview(localPalette);
@@ -22,7 +22,8 @@ const UseCase = ({ palette, ColorPicker, link, title }) => {
 					width: 320,
 					paletteHeight: 32,
 					palette: localPalette,
-					onPaletteChange: setLocalPalette
+					onPaletteChange: setLocalPalette,
+					floatingPicker: floatingPicker
 				}}>
 					{ ColorPicker ? <ColorPicker/> : null }
 				</GradientPicker>

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -55,6 +55,13 @@ storiesOf('Gradient Picker', module)
 	))
 	.add('Default Color Picker', () => (
 		<UseCase title="Default Picker" palette={[{ offset: '0', color: '#FF0000' }, { offset: '0.3', color: '#00FF00' }, { offset: '1', color: '#0000FF' }]}/>
+	))
+	.add('Floating color picker', () => (
+		<UseCase palette={[
+			{ offset: '0.00', color: '#7e20cf' },
+			{ offset: '0.42', color: '#d0021b' },
+			{ offset: '1.00', color: '#00ccff' }
+		]}  title={'floatingPicker'} floatingPicker ColorPicker={WrappedColorPicker}/>
 	));
 
 storiesOf('Angle Picker', module)

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { storiesOf } from '@storybook/react';
 import { SketchPicker } from 'react-color';
 import { Panel as ColorPicker } from 'rc-color-picker';
-import { AnglePicker } from '../src';
+import { AnglePicker, GradientPicker } from '../src';
 import UseCase from './UseCase';
 import './Story.css';
 import 'rc-color-picker/assets/index.css';
@@ -81,4 +81,31 @@ storiesOf('Angle Picker', module)
 		);
 	});
 
+storiesOf('Gradient + Angle picker', module)
+	.add('Default', () => {
+		const [angle, setAngle] = useState(0);
+		const [localPalette, setLocalPalette] = useState([
+			{ offset: '0.00', color: '#7e20cf' },
+			{ offset: '0.42', color: '#d0021b' },
+			{ offset: '1.00', color: '#00ccff' }
+		]);
 
+		return (
+			<div className="agps">
+				<h4>Floating picker & angle picker (with showValue)</h4>
+				<div style={{display: 'flex', alignItems: 'center'}}>
+					<GradientPicker {...{
+						width: 320,
+						paletteHeight: 32,
+						palette: localPalette,
+						floatingPicker: true,
+						angle,
+						onPaletteChange: setLocalPalette
+					}}>
+						<WrappedColorPicker />
+					</GradientPicker>
+					<AnglePicker angle={angle} onChange={setAngle} showValue/>
+				</div>
+			</div>
+		);
+	});


### PR DESCRIPTION
Hey!
I really like the gradient picker, but I don't like to have the color pickers displayed permanently. 
This feature allow to hide the color picker by default and show it only when a color stop is clicked. 
I added a story and updated the doc. 
Let me know if you need me to change something.