### PR TITLE
[FEAT] Popover picker type as prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-linear-gradient-picker",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "React linear gradient picker",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/GradientPickerPopover/index.js
+++ b/src/components/GradientPickerPopover/index.js
@@ -21,9 +21,14 @@ const GradientPickerPopover = ({
 	showGradientTypePicker = true,
 	angle,
 	setAngle,
+	gradientType: controlledGradientType,
+	setGradientType: setControlledGradientType,
 	...gradientPickerProps
 }) => {
-	const [gradientType, setGradientType] = useState(GRADIENT_TYPES.LINEAR);
+	const [internalGradientType, setInternalGradientType] = useState(controlledGradientType || GRADIENT_TYPES.LINEAR);
+	const gradientType = controlledGradientType || internalGradientType;
+	const setGradientType = setControlledGradientType || setInternalGradientType;
+
 	const togglePicker = () => setOpen(!open);
 	const { background } = getGradientPreview(palette, angle, gradientType);
 
@@ -55,5 +60,7 @@ const GradientPickerPopover = ({
 };
 
 GradientPickerPopover.propTypes = GRADIENT_PICKER_POPOVER_PROP_TYPES;
+
+export { GRADIENT_TYPES };
 
 export default GradientPickerPopover;

--- a/src/components/GradientPickerPopover/index.js
+++ b/src/components/GradientPickerPopover/index.js
@@ -25,7 +25,7 @@ const GradientPickerPopover = ({
 	setGradientType: setControlledGradientType,
 	...gradientPickerProps
 }) => {
-	const [internalGradientType, setInternalGradientType] = useState(controlledGradientType || GRADIENT_TYPES.LINEAR);
+	const [internalGradientType, setInternalGradientType] = useState(GRADIENT_TYPES.LINEAR);
 	const gradientType = controlledGradientType || internalGradientType;
 	const setGradientType = setControlledGradientType || setInternalGradientType;
 

--- a/src/components/GradientTypePicker/index.js
+++ b/src/components/GradientTypePicker/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { func, string } from 'prop-types';
 import './index.scss';
 
-const GRADIENT_TYPES = {
+export const GRADIENT_TYPES = {
 	LINEAR: 'linear',
 	RADIAL: 'radial'
 };
@@ -27,7 +27,5 @@ GradientTypePicker.propTypes = {
 	gradientType: string,
 	onGradientTypeChange: func
 };
-
-export { GRADIENT_TYPES };
 
 export default GradientTypePicker;

--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,12 @@
 import { getGradientPreview } from './lib';
 import AnglePicker from './components/AnglePicker';
 import GradientPicker from './components/GradientPicker';
-import GradientPickerPopover from './components/GradientPickerPopover';
+import GradientPickerPopover, { GRADIENT_TYPES } from './components/GradientPickerPopover';
 
 export {
 	GradientPicker,
 	GradientPickerPopover,
 	AnglePicker,
-	getGradientPreview
+	getGradientPreview,
+	GRADIENT_TYPES
 };

--- a/stories/Popover/index.js
+++ b/stories/Popover/index.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { SketchPicker } from 'react-color';
-import GradientPickerPopover from '../../src/components/GradientPickerPopover';
+import GradientPickerPopover, { GRADIENT_TYPES } from '../../src/components/GradientPickerPopover';
 import './index.css';
 
 /**
@@ -43,6 +43,7 @@ const initialPallet = [
 const PopoverStory = ({ showAngle, showType}) => {
 	const [open, setOpen] = useState(false);
 	const [angle, setAngle] = useState(90);
+	const [gradientType, setGradientType] = useState(GRADIENT_TYPES.RADIAL);
 	const [palette, setPalette] = useState(initialPallet);
 
 	return (
@@ -57,7 +58,9 @@ const PopoverStory = ({ showAngle, showType}) => {
 			maxStops: 3,
 			paletteHeight: 32,
 			palette,
-			onPaletteChange: setPalette
+			onPaletteChange: setPalette,
+			gradientType,
+			setGradientType
 		}}>
 			<WrappedSketchPicker/>
 		</GradientPickerPopover>

--- a/stories/Popover/index.js
+++ b/stories/Popover/index.js
@@ -43,7 +43,7 @@ const initialPallet = [
 const PopoverStory = ({ showAngle, showType}) => {
 	const [open, setOpen] = useState(false);
 	const [angle, setAngle] = useState(90);
-	const [gradientType, setGradientType] = useState(GRADIENT_TYPES.RADIAL);
+	const [gradientType, setGradientType] = useState(GRADIENT_TYPES.LINEAR);
 	const [palette, setPalette] = useState(initialPallet);
 
 	return (


### PR DESCRIPTION
**Main changes:**
- Adding an option to control the `gradientType` externally, defaults to an internal state if not provided.


Resolves: https://github.com/odedglas/react-linear-gradient-picker/issues/31